### PR TITLE
fix: Usa objeto routes na navegacao apos criar colaborador

### DIFF
--- a/src/hooks/useCreateUser/index.js
+++ b/src/hooks/useCreateUser/index.js
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router";
+import { routes, tipoUsuario } from "@nabstore/utils";
 import usersMethods from "../../services/users";
 
 const useCreateUser = () => {
@@ -21,10 +22,10 @@ const useCreateUser = () => {
         setData(resp);
         setError(undefined);
         setIsLoading(false);
-        if (tipoUsuarioId === 1) {
-          navigate(`/users/login`);
+        if (tipoUsuarioId === tipoUsuario.CLIENTE) {
+          navigate(routes.LOGIN);
         } else {
-          navigate(`/`);
+          navigate(routes.HOME);
         }
       })
       .catch((err) => {


### PR DESCRIPTION
# Descrição

No hook de criar colaborador a navegação após cadastrar com sucesso não estava usando as rotas do objeto `routes` da utils, então estava direcionando às páginas monolito.
